### PR TITLE
Fix GitHub import errors and clarify invalid project failures

### DIFF
--- a/cloudpebble/cloudpebble/settings.py
+++ b/cloudpebble/cloudpebble/settings.py
@@ -4,6 +4,7 @@
 import sys
 import os
 import socket
+from urllib.parse import urlsplit, urlunsplit
 import dj_database_url
 
 _environ = os.environ
@@ -353,11 +354,19 @@ if TESTING:
 
 REDIS_URL = _environ.get('REDIS_URL', None) or _environ.get('REDISCLOUD_URL', 'redis://redis:6379')
 
+
+def _redis_db_url(redis_url, db_index):
+    parsed_url = urlsplit(redis_url)
+    if parsed_url.scheme != 'redis':
+        return redis_url.rstrip('/') + '/' + str(db_index)
+    return urlunsplit(parsed_url._replace(path='/' + str(db_index)))
+
+
 # Celery 5.x configuration
 if REDIS_URL.startswith('rediss://'):
     CELERY_BROKER_URL = REDIS_URL
 else:
-    CELERY_BROKER_URL = REDIS_URL + '/1'
+    CELERY_BROKER_URL = _redis_db_url(REDIS_URL, 1)
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 CELERY_ACCEPT_CONTENT = ['pickle']
 CELERY_TASK_SERIALIZER = 'pickle'

--- a/cloudpebble/ide/tasks/git.py
+++ b/cloudpebble/ide/tasks/git.py
@@ -24,6 +24,13 @@ __author__ = 'katharine'
 logger = logging.getLogger(__name__)
 
 
+def exception_reason(error):
+    reason = str(error)
+    if reason:
+        return reason
+    return error.__class__.__name__
+
+
 @shared_task(acks_late=True)
 def do_import_github(project_id, github_user, github_project, github_branch, delete_project=False):
     try:
@@ -47,7 +54,7 @@ def do_import_github(project_id, github_user, github_project, github_branch, del
                 pass
         send_td_event('cloudpebble_github_import_failed', data={
             'data': {
-                'reason': e.message,
+                'reason': exception_reason(e),
                 'github_user': github_user,
                 'github_project': github_project,
                 'github_branch': github_branch

--- a/cloudpebble/ide/utils/project.py
+++ b/cloudpebble/ide/utils/project.py
@@ -99,4 +99,10 @@ def find_project_root_and_manifest(project_items):
     if invalid_package_path:
         raise InvalidProjectArchiveException(_("The file %s does not contain a valid JSON object." % invalid_package_path))
     else:
-        raise InvalidProjectArchiveException(_("No valid project root found."))
+        raise InvalidProjectArchiveException(
+            _(
+                "No valid Pebble project root found. Expected either a package.json "
+                "with a top-level 'pebble' object, or an appinfo.json with source "
+                "files under src/."
+            )
+        )


### PR DESCRIPTION
## Summary
  This PR fixes GitHub import failures caused by error handling and Redis URL parsing issues, and improves the invalid-project error message shown during import.

  ## Changes
  - `cloudpebble/cloudpebble/settings.py`
    - Build Celery Redis DB URL safely when `REDIS_URL` already includes a DB path.
  - `cloudpebble/ide/tasks/git.py`
    - Replace `e.message` with `str(exception)` for Python 3-compatible error reporting.
  - `cloudpebble/ide/utils/project.py`
    - Keep strict Pebble project validation as-is, but return a clearer message when no valid project
  root is found.

|Previous Error Message|New Error Message|
|---|---|
|![Previous Error Message](https://private-user-images.githubusercontent.com/164192/552966338-f6298e29-e910-4d6a-8a62-98b99ecfcae3.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzE3MTc4OTQsIm5iZiI6MTc3MTcxNzU5NCwicGF0aCI6Ii8xNjQxOTIvNTUyOTY2MzM4LWY2Mjk4ZTI5LWU5MTAtNGQ2YS04YTYyLTk4Yjk5ZWNmY2FlMy5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjYwMjIxJTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI2MDIyMVQyMzQ2MzRaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT00NDNhMWM3M2JmYzU1MGY3ZGMyNDQzODA4MmY2Nzc0MWU0YzFhNjE1OTUxZWZiNDIyYTAzYTlmZDI5ZjFmOGFlJlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCJ9.fst9M4Bg40RELsXhVhzI_lx1qg90chWueShtN5-wWIY)|![New Error Message](https://github.com/user-attachments/assets/dc58fb05-4b12-43ee-a0ae-c5b86aa99ba4)|

  ## Validation
  - `python3 -m py_compile cloudpebble/cloudpebble/settings.py cloudpebble/ide/tasks/git.py cloudpebble/ide/utils/project.py`

  ## Related
  - Resolves #3