### PR TITLE
Fix GitHub repo-link access check for PyGithub 2.x

### DIFF
--- a/cloudpebble/ide/git.py
+++ b/cloudpebble/ide/git.py
@@ -58,11 +58,11 @@ def get_github(user):
 def check_repo_access(user, repo):
     g = get_github(user)
     try:
-        repo = g.get_repo(repo)
+        repo_obj = g.get_repo(repo)
     except UnknownObjectException:
         raise
 
-    return repo.has_in_collaborators(NamedUser(None, {'login': user.github_repo_sync.username}, False))
+    return repo_obj.has_in_collaborators(user.github_repo_sync.username)
 
 
 def url_to_repo(url):


### PR DESCRIPTION
### Fix GitHub repo linking crash with current PyGithub

  When users saved a GitHub repo link, the request could fail with a 500 error.

  #### What was broken

  CloudPebble called has_in_collaborators() by manually creating a NamedUser object.
  That constructor shape no longer matches current PyGithub, which caused:

  ```CompletableGithubObject.__init__() missing 1 required positional argument: 'completed'```

  #### What changed

  We now pass the GitHub username string directly to has_in_collaborators() instead of constructing NamedUser ourselves.

  #### Why this is correct

  `has_in_collaborators()` supports a username string, and this avoids direct dependence on PyGithub internal constructor details.

  #### Outcome

  Repo linking no longer crashes on this path, and users no longer see a generic "An error has occurred" response for this specific failure.
  
  Likely fixes #7 #8 #9