### PR TITLE
Force SigV4 for CloudPebble S3 presigned URLs

### DIFF
--- a/cloudpebble/utils/s3.py
+++ b/cloudpebble/utils/s3.py
@@ -32,6 +32,8 @@ class BucketHolder(object):
     def configure(self):
         if settings.AWS_ENABLED:
             endpoint_url = getattr(settings, 'AWS_S3_ENDPOINT_URL', None)
+            s3v4_config = Config(signature_version='s3v4')
+            s3v4_path_config = Config(signature_version='s3v4', s3={'addressing_style': 'path'})
             if settings.AWS_S3_FAKE_S3 is not None:
                 # Fake S3 (e.g., minio, fake-s3) — local dev
                 host, port = (settings.AWS_S3_FAKE_S3.split(':', 2) + ['80'])[:2]
@@ -43,14 +45,14 @@ class BucketHolder(object):
                     aws_access_key_id='key_id',
                     aws_secret_access_key='secret_key',
                     endpoint_url=fake_endpoint,
-                    config=Config(s3={'addressing_style': 'path'}),
+                    config=s3v4_path_config,
                 )
                 self.s3_resource = boto3.resource(
                     's3',
                     aws_access_key_id='key_id',
                     aws_secret_access_key='secret_key',
                     endpoint_url=fake_endpoint,
-                    config=Config(s3={'addressing_style': 'path'}),
+                    config=s3v4_path_config,
                 )
                 self.supports_acl = True
 
@@ -64,14 +66,14 @@ class BucketHolder(object):
                     aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
                     aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
                     endpoint_url=endpoint_url,
-                    config=Config(s3={'addressing_style': 'path'}),
+                    config=s3v4_path_config,
                 )
                 self.s3_resource = boto3.resource(
                     's3',
                     aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
                     aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
                     endpoint_url=endpoint_url,
-                    config=Config(s3={'addressing_style': 'path'}),
+                    config=s3v4_path_config,
                 )
                 self.supports_acl = False
             else:
@@ -81,12 +83,14 @@ class BucketHolder(object):
                     aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
                     aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
                     region_name=getattr(settings, 'AWS_S3_REGION', 'us-east-1'),
+                    config=s3v4_config,
                 )
                 self.s3_resource = boto3.resource(
                     's3',
                     aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
                     aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
                     region_name=getattr(settings, 'AWS_S3_REGION', 'us-east-1'),
+                    config=s3v4_config,
                 )
                 self.supports_acl = True
 


### PR DESCRIPTION
### Motivation
- Resource image preview URLs were being rejected by S3-compatible providers that no longer accept Signature Version 2 (`UnauthorizedSigV2 ... Please use SigV4 instead`), so the S3 clients must explicitly use SigV4.
- We need to keep existing path-style addressing for local/fake S3 endpoints (MinIO / fake-s3) while ensuring SigV4 is used for signing.

### Description
- Updated `cloudpebble/utils/s3.py` to create two `botocore.config.Config` objects: `s3v4_config` (SigV4) and `s3v4_path_config` (SigV4 + `addressing_style: path`).
- Replaced previous `Config(s3={'addressing_style': 'path'})` usages with `s3v4_path_config` for fake/custom endpoints and applied `s3v4_config` for real AWS S3 client/resource construction.
- This forces all `boto3` clients/resources used by the app to use Signature Version 4 while preserving path-style addressing where required.

### Testing
- Ran `python -m compileall utils/s3.py`, which completed successfully.
- Ran `pytest -q tests/test_filter_dict.py`, which failed during collection due to an existing Python 2-style `print` statement in `tests/test_filter_dict.py` (test failure is unrelated to the S3 changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f4093be14832ba4b2a8a9c11fc302)