### PR TITLE
Make GitHub Repo Sync safe for combined install + auth rollout

### DIFF
--- a/cloudpebble/ide/templates/ide/settings.html
+++ b/cloudpebble/ide/templates/ide/settings.html
@@ -43,6 +43,11 @@
     </div>
     <div class="github-settings">
         <h2 class="section-heading">{% trans 'GitHub Integrations' %}</h2>
+        {% if messages %}
+        {% for message in messages %}
+        <div class="well alert {% if message.tags %}alert-{{ message.tags }}{% endif %}">{{ message }}</div>
+        {% endfor %}
+        {% endif %}
         <div class="well github-card">
             <h3 class="github-card-title">{% trans 'GitHub Repo Sync' %}</h3>
             {% if github_repo_sync and github_repo_sync.token %}
@@ -63,9 +68,10 @@
                     {% csrf_token %}
                 </form>
                 {% else %}
-                <a href="https://github.com/apps/cloudpebble-repo-sync/installations/new" target="_blank" rel="noopener" class="btn">
-                    {% trans 'Install GitHub app' %}
-                </a>
+                <form method="post" action="{% url 'ide:start_github_repo_sync_install' %}" class="github-action" target="_blank">
+                    <input type="submit" class="btn" value="{% trans 'Install GitHub app' %}">
+                    {% csrf_token %}
+                </form>
                 <form method="post" action="{% url 'ide:start_github_repo_sync_auth' %}" class="github-action">
                     <input type="submit" class="btn btn-primary" value="{% trans 'Link your GitHub account' %}">
                     {% csrf_token %}

--- a/cloudpebble/ide/tests/test_github_repo_sync.py
+++ b/cloudpebble/ide/tests/test_github_repo_sync.py
@@ -1,0 +1,322 @@
+import os
+import sys
+import types
+import urllib.parse
+from io import BytesIO
+from unittest import mock
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'cloudpebble.settings')
+
+import django
+
+django.setup()
+
+fake_td_helper = types.ModuleType('utils.td_helper')
+fake_td_helper.send_td_event = lambda *args, **kwargs: None
+sys.modules.setdefault('utils.td_helper', fake_td_helper)
+
+from django.test import RequestFactory, SimpleTestCase
+try:
+    from django.test import override_settings
+except ImportError:
+    from django.test.utils import override_settings
+
+from ide.models.user import UserGithub, UserGithubRepoSync, UserSettings
+from ide.views.settings import (
+    complete_github_repo_sync_auth,
+    settings_page,
+    start_github_repo_sync_auth,
+    start_github_repo_sync_install,
+)
+
+
+class DummySession(dict):
+    modified = False
+    accessed = False
+
+    def __setitem__(self, key, value):
+        self.modified = True
+        super(DummySession, self).__setitem__(key, value)
+
+    def save(self):
+        pass
+
+
+class DummyMessages(object):
+    def __init__(self):
+        self.messages = []
+
+    def add(self, level, message, extra_tags=''):
+        self.messages.append(message)
+
+    def __iter__(self):
+        return iter(self.messages)
+
+
+class FakeRepoSync(object):
+    def __init__(self, nonce=None, token=None, username=None, avatar=None):
+        self.nonce = nonce
+        self.token = token
+        self.username = username
+        self.avatar = avatar
+        self.save_calls = 0
+
+    def save(self):
+        self.save_calls += 1
+
+
+class FakeUser(object):
+    is_authenticated = True
+
+    def __init__(self, github_repo_sync=None):
+        self.settings = UserSettings()
+        self._github_repo_sync = github_repo_sync
+
+    @property
+    def github(self):
+        raise UserGithub.DoesNotExist
+
+    @property
+    def github_repo_sync(self):
+        if self._github_repo_sync is None:
+            raise UserGithubRepoSync.DoesNotExist
+        return self._github_repo_sync
+
+
+@override_settings(
+    GITHUB_SYNC_CLIENT_ID='client-id',
+    GITHUB_SYNC_CLIENT_SECRET='client-secret',
+    PUBLIC_URL='http://localhost:8080/',
+)
+class TestGithubRepoSync(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.send_td_event_patcher = mock.patch('ide.views.settings.send_td_event')
+        self.send_td_event_patcher.start()
+        self.addCleanup(self.send_td_event_patcher.stop)
+
+    def _request(self, method, path, user, data=None, with_messages=False):
+        if method == 'post':
+            request = self.factory.post(path, data or {})
+        else:
+            request = self.factory.get(path, data or {})
+        request.user = user
+        request.session = DummySession()
+        if with_messages:
+            request._messages = DummyMessages()
+        return request
+
+    @override_settings(
+        GITHUB_SYNC_CLIENT_ID='',
+        GITHUB_SYNC_CLIENT_SECRET='',
+    )
+    def test_install_route_redirects_to_github_install_without_oauth_config(self):
+        user = FakeUser()
+        repo_sync = FakeRepoSync()
+
+        def create_repo_sync(**kwargs):
+            kwargs['user']._github_repo_sync = repo_sync
+            return repo_sync
+
+        request = self._request('post', '/ide/settings/github-sync/install', user)
+
+        with mock.patch('ide.views.settings.uuid.uuid4', return_value=mock.Mock(hex='install-state')):
+            with mock.patch('ide.views.settings.UserGithubRepoSync.objects.create', side_effect=create_repo_sync):
+                response = start_github_repo_sync_install(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response['Location'],
+            'https://github.com/apps/cloudpebble-repo-sync/installations/new?state=install-state',
+        )
+        self.assertEqual(
+            request.session['github_repo_sync_pending_states'],
+            ['install-state'],
+        )
+
+    def test_install_route_stores_nonce_and_redirects_to_github_install(self):
+        user = FakeUser()
+        repo_sync = FakeRepoSync()
+
+        def create_repo_sync(**kwargs):
+            kwargs['user']._github_repo_sync = repo_sync
+            return repo_sync
+
+        request = self._request('post', '/ide/settings/github-sync/install', user)
+
+        with mock.patch('ide.views.settings.uuid.uuid4', return_value=mock.Mock(hex='install-state')):
+            with mock.patch('ide.views.settings.UserGithubRepoSync.objects.create', side_effect=create_repo_sync):
+                response = start_github_repo_sync_install(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response['Location'],
+            'https://github.com/apps/cloudpebble-repo-sync/installations/new?state=install-state',
+        )
+        self.assertEqual(repo_sync.nonce, 'install-state')
+        self.assertEqual(repo_sync.save_calls, 1)
+        self.assertEqual(
+            request.session['github_repo_sync_pending_states'],
+            ['install-state'],
+        )
+
+    def test_auth_route_still_redirects_to_github_auth(self):
+        user = FakeUser()
+        repo_sync = FakeRepoSync()
+
+        def create_repo_sync(**kwargs):
+            kwargs['user']._github_repo_sync = repo_sync
+            return repo_sync
+
+        request = self._request('post', '/ide/settings/github-sync/start', user)
+
+        with mock.patch('ide.views.settings.uuid.uuid4', return_value=mock.Mock(hex='auth-state')):
+            with mock.patch('ide.views.settings.UserGithubRepoSync.objects.create', side_effect=create_repo_sync):
+                response = start_github_repo_sync_auth(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('https://github.com/login/oauth/authorize?', response['Location'])
+        self.assertIn('state=auth-state', response['Location'])
+        self.assertIn(
+            urllib.parse.quote('http://localhost:8080/ide/settings/github-sync/callback', safe=''),
+            response['Location'],
+        )
+        self.assertEqual(repo_sync.nonce, 'auth-state')
+        self.assertEqual(repo_sync.save_calls, 1)
+        self.assertEqual(
+            request.session['github_repo_sync_pending_states'],
+            ['auth-state'],
+        )
+
+    @override_settings(
+        GITHUB_SYNC_CLIENT_ID='',
+        GITHUB_SYNC_CLIENT_SECRET='',
+    )
+    def test_auth_route_still_requires_oauth_config(self):
+        request = self._request('post', '/ide/settings/github-sync/start', FakeUser())
+
+        response = start_github_repo_sync_auth(request)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn(b'GitHub Repo Sync app is not configured.', response.content)
+
+    def test_install_and_auth_paths_keep_multiple_pending_states(self):
+        repo_sync = FakeRepoSync()
+        user = FakeUser(github_repo_sync=repo_sync)
+        install_request = self._request('post', '/ide/settings/github-sync/install', user)
+
+        with mock.patch('ide.views.settings.uuid.uuid4', return_value=mock.Mock(hex='install-state')):
+            install_response = start_github_repo_sync_install(install_request)
+
+        auth_request = self._request('post', '/ide/settings/github-sync/start', user)
+        auth_request.session = install_request.session
+
+        with mock.patch('ide.views.settings.uuid.uuid4', return_value=mock.Mock(hex='auth-state')):
+            auth_response = start_github_repo_sync_auth(auth_request)
+
+        self.assertEqual(install_response.status_code, 302)
+        self.assertEqual(auth_response.status_code, 302)
+        self.assertEqual(
+            auth_request.session['github_repo_sync_pending_states'],
+            ['install-state', 'auth-state'],
+        )
+
+    def test_pending_states_are_capped_to_the_newest_three(self):
+        repo_sync = FakeRepoSync()
+        user = FakeUser(github_repo_sync=repo_sync)
+        request = self._request('post', '/ide/settings/github-sync/install', user)
+
+        for state in ['state-1', 'state-2', 'state-3', 'state-4']:
+            with mock.patch('ide.views.settings.uuid.uuid4', return_value=mock.Mock(hex=state)):
+                start_github_repo_sync_install(request)
+
+        self.assertEqual(
+            request.session['github_repo_sync_pending_states'],
+            ['state-2', 'state-3', 'state-4'],
+        )
+
+    @mock.patch('ide.views.settings.urlopen')
+    def test_callback_links_repo_sync_with_valid_session_state_and_code(self, urlopen):
+        repo_sync = FakeRepoSync(nonce='nonce')
+        user = FakeUser(github_repo_sync=repo_sync)
+        request = self._request(
+            'get',
+            '/ide/settings/github-sync/callback',
+            user,
+            {'state': 'install-state', 'code': 'auth-code'},
+            with_messages=True,
+        )
+        request.session['github_repo_sync_pending_states'] = ['install-state', 'auth-state']
+
+        urlopen.side_effect = [
+            BytesIO(b'{"access_token": "token"}'),
+            BytesIO(b'{"login": "repo-sync-user", "avatar_url": "https://example.com/avatar.png"}'),
+        ]
+
+        response = complete_github_repo_sync_auth(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], '/ide/settings')
+        self.assertEqual(repo_sync.token, 'token')
+        self.assertEqual(repo_sync.username, 'repo-sync-user')
+        self.assertEqual(repo_sync.avatar, 'https://example.com/avatar.png')
+        self.assertIsNone(repo_sync.nonce)
+        self.assertEqual(repo_sync.save_calls, 1)
+        self.assertEqual(
+            request.session['github_repo_sync_pending_states'],
+            ['auth-state'],
+        )
+
+    @mock.patch('ide.views.settings.urlopen')
+    def test_callback_still_accepts_legacy_model_nonce(self, urlopen):
+        repo_sync = FakeRepoSync(nonce='nonce')
+        user = FakeUser(github_repo_sync=repo_sync)
+        request = self._request(
+            'get',
+            '/ide/settings/github-sync/callback',
+            user,
+            {'state': 'nonce', 'code': 'auth-code'},
+            with_messages=True,
+        )
+
+        urlopen.side_effect = [
+            BytesIO(b'{"access_token": "token"}'),
+            BytesIO(b'{"login": "repo-sync-user", "avatar_url": "https://example.com/avatar.png"}'),
+        ]
+
+        response = complete_github_repo_sync_auth(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], '/ide/settings')
+        self.assertEqual(repo_sync.token, 'token')
+        self.assertEqual(repo_sync.username, 'repo-sync-user')
+        self.assertEqual(repo_sync.avatar, 'https://example.com/avatar.png')
+        self.assertIsNone(repo_sync.nonce)
+
+    def test_callback_with_missing_or_mismatched_state_redirects_to_settings(self):
+        user = FakeUser(github_repo_sync=FakeRepoSync(nonce='expected-nonce'))
+        request = self._request(
+            'get',
+            '/ide/settings/github-sync/callback',
+            user,
+            {'state': 'wrong-nonce', 'code': 'auth-code'},
+            with_messages=True,
+        )
+
+        response = complete_github_repo_sync_auth(request)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response['Location'], '/ide/settings')
+        self.assertEqual(
+            list(request._messages),
+            ['GitHub connection could not be completed. Start again from Settings.'],
+        )
+
+    def test_settings_page_keeps_existing_repo_sync_buttons(self):
+        request = self._request('get', '/ide/settings', FakeUser(), with_messages=True)
+
+        response = settings_page(request)
+
+        self.assertContains(response, 'Install GitHub app')
+        self.assertContains(response, 'Link your GitHub account')
+        self.assertContains(response, 'target="_blank"')

--- a/cloudpebble/ide/urls.py
+++ b/cloudpebble/ide/urls.py
@@ -64,6 +64,7 @@ from ide.views.settings import (
     start_github_dev_auth,
     remove_github_dev_auth,
     complete_github_dev_auth,
+    start_github_repo_sync_install,
     start_github_repo_sync_auth,
     remove_github_repo_sync_auth,
     complete_github_repo_sync_auth,
@@ -249,6 +250,11 @@ urlpatterns = [
         r"^settings/github/callback$", complete_github_dev_auth, name="complete_github_dev_auth"
     ),
     re_path(r"^settings/github/unlink$", remove_github_dev_auth, name="remove_github_dev_auth"),
+    re_path(
+        r"^settings/github-sync/install$",
+        start_github_repo_sync_install,
+        name="start_github_repo_sync_install",
+    ),
     re_path(
         r"^settings/github-sync/start$",
         start_github_repo_sync_auth,

--- a/cloudpebble/ide/views/settings.py
+++ b/cloudpebble/ide/views/settings.py
@@ -3,6 +3,7 @@ from urllib.request import urlopen, Request
 import uuid
 import json
 from django.conf import settings
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseRedirect, HttpResponseBadRequest
 from django.shortcuts import render
@@ -12,6 +13,9 @@ from ide.models.user import UserGithub, UserGithubRepoSync
 from utils.td_helper import send_td_event
 
 __author__ = 'katharine'
+
+GITHUB_REPO_SYNC_PENDING_STATES_SESSION_KEY = 'github_repo_sync_pending_states'
+GITHUB_REPO_SYNC_MAX_PENDING_STATES = 3
 
 
 @login_required
@@ -69,6 +73,12 @@ def _complete_github_auth(request, model, client_id, client_secret, callback_pat
     if user_github.nonce is None or nonce != user_github.nonce:
         return HttpResponseBadRequest('nonce mismatch.')
 
+    _store_github_token_and_profile(user_github, client_id, client_secret, callback_path, code)
+
+    return user_github
+
+
+def _store_github_token_and_profile(user_github, client_id, client_secret, callback_path, code):
     redirect_uri = settings.PUBLIC_URL.rstrip('/') + callback_path
     params = urllib.parse.urlencode({
         'client_id': client_id,
@@ -88,7 +98,36 @@ def _complete_github_auth(request, model, client_id, client_secret, callback_pat
     user_github.avatar = profile_result['avatar_url']
     user_github.save()
 
+
+def _start_repo_sync_session(user):
+    try:
+        user_github = user.github_repo_sync
+    except UserGithubRepoSync.DoesNotExist:
+        user_github = UserGithubRepoSync.objects.create(user=user)
+    user_github.nonce = uuid.uuid4().hex
+    user_github.save()
     return user_github
+
+
+def _get_pending_repo_sync_states(request):
+    return request.session.get(GITHUB_REPO_SYNC_PENDING_STATES_SESSION_KEY, [])
+
+
+def _add_pending_repo_sync_state(request, state):
+    pending_states = list(_get_pending_repo_sync_states(request))
+    if state in pending_states:
+        pending_states.remove(state)
+    pending_states.append(state)
+    request.session[GITHUB_REPO_SYNC_PENDING_STATES_SESSION_KEY] = pending_states[-GITHUB_REPO_SYNC_MAX_PENDING_STATES:]
+
+
+def _consume_pending_repo_sync_state(request, state):
+    pending_states = list(_get_pending_repo_sync_states(request))
+    if state not in pending_states:
+        return False
+    pending_states.remove(state)
+    request.session[GITHUB_REPO_SYNC_PENDING_STATES_SESSION_KEY] = pending_states
+    return True
 
 
 @login_required
@@ -143,18 +182,25 @@ def complete_github_dev_auth(request):
 
 @login_required
 @require_POST
+def start_github_repo_sync_install(request):
+    user_github = _start_repo_sync_session(request.user)
+    _add_pending_repo_sync_state(request, user_github.nonce)
+    send_td_event('cloudpebble_github_repo_sync_started', request=request)
+    return HttpResponseRedirect(
+        'https://github.com/apps/cloudpebble-repo-sync/installations/new?state=%s'
+        % urllib.parse.quote(user_github.nonce, safe='')
+    )
+
+
+@login_required
+@require_POST
 def start_github_repo_sync_auth(request):
     if not settings.GITHUB_SYNC_CLIENT_ID or not settings.GITHUB_SYNC_CLIENT_SECRET:
         return HttpResponseBadRequest('GitHub Repo Sync app is not configured.')
-    nonce = uuid.uuid4().hex
-    try:
-        user_github = request.user.github_repo_sync
-    except UserGithubRepoSync.DoesNotExist:
-        user_github = UserGithubRepoSync.objects.create(user=request.user)
-    user_github.nonce = nonce
-    user_github.save()
+    user_github = _start_repo_sync_session(request.user)
+    _add_pending_repo_sync_state(request, user_github.nonce)
     send_td_event('cloudpebble_github_repo_sync_started', request=request)
-    return _github_auth_redirect(settings.GITHUB_SYNC_CLIENT_ID, nonce, '/ide/settings/github-sync/callback')
+    return _github_auth_redirect(settings.GITHUB_SYNC_CLIENT_ID, user_github.nonce, '/ide/settings/github-sync/callback')
 
 
 @login_required
@@ -173,18 +219,34 @@ def remove_github_repo_sync_auth(request):
 @require_safe
 def complete_github_repo_sync_auth(request):
     if 'error' in request.GET:
+        messages.error(request, 'GitHub connection could not be completed. Start again from Settings.')
         return HttpResponseRedirect('/ide/settings')
     if not settings.GITHUB_SYNC_CLIENT_ID or not settings.GITHUB_SYNC_CLIENT_SECRET:
         return HttpResponseBadRequest('GitHub Repo Sync app is not configured.')
-    user_github = _complete_github_auth(
-        request,
-        UserGithubRepoSync,
+
+    nonce = request.GET.get('state')
+    code = request.GET.get('code')
+    if not nonce or not code:
+        messages.error(request, 'GitHub connection could not be completed. Start again from Settings.')
+        return HttpResponseRedirect('/ide/settings')
+
+    try:
+        user_github = request.user.github_repo_sync
+    except UserGithubRepoSync.DoesNotExist:
+        messages.error(request, 'GitHub connection could not be completed. Start again from Settings.')
+        return HttpResponseRedirect('/ide/settings')
+    matched_pending_state = _consume_pending_repo_sync_state(request, nonce)
+    if not matched_pending_state and (user_github.nonce is None or nonce != user_github.nonce):
+        messages.error(request, 'GitHub connection could not be completed. Start again from Settings.')
+        return HttpResponseRedirect('/ide/settings')
+
+    _store_github_token_and_profile(
+        user_github,
         settings.GITHUB_SYNC_CLIENT_ID,
         settings.GITHUB_SYNC_CLIENT_SECRET,
-        '/ide/settings/github-sync/callback'
+        '/ide/settings/github-sync/callback',
+        code
     )
-    if user_github is None:
-        return HttpResponseBadRequest('Missing GitHub auth session.')
     send_td_event('cloudpebble_github_repo_sync_linked', data={
         'data': {'username': user_github.username}
     }, request=request)


### PR DESCRIPTION
GitHub can be configured to authorize the user during app installation, but CloudPebble's Repo Sync flow was not ready for that callback. This change adds the minimum compatibility needed so that GitHub App setting can be enabled later without breaking the current deployment.

- add /ide/settings/github-sync/install and route the install button through CloudPebble first so we can create and store a valid state before sending the user to GitHub
- keep the existing auth button and current two-step setup working
- keep the install action opening in a new tab so today's GitHub install behavior does not pull the user away from Settings
- make the Repo Sync callback handle both the current auth-only flow and the future install+auth return path
- replace raw callback 400s with a normal Settings error message
- allow install and auth to overlap safely by tracking a small bounded list of pending Repo Sync states in the session
- add focused Repo Sync view tests for install, auth, callback success, callback failure, install without local OAuth config, and overlapping install/auth attempts