### PR TITLE
Fix celery package dependency downloads in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
       - AWS_S3_SOURCE_BUCKET=${AWS_S3_SOURCE_BUCKET:-source.cloudpebble.net}
       - AWS_S3_BUILDS_BUCKET=${AWS_S3_BUILDS_BUCKET:-builds.cloudpebble.net}
       - AWS_S3_EXPORT_BUCKET=${AWS_S3_EXPORT_BUCKET:-export.cloudpebble.net}
+      - MEDIA_URL=http://nginx/s3builds/
       - PUBLIC_URL=${PUBLIC_URL}/
       - GITHUB_ID=${GITHUB_ID:-}
       - GITHUB_SECRET=${GITHUB_SECRET:-}


### PR DESCRIPTION
Expected:
Package dependencies should install successfully during a project build.

What happened:
Celery ran npm install with a dependency URL under http://localhost:8001/builds/. Inside the celery container, localhost pointed back to the container itself, so npm failed with ECONNREFUSED when fetching package.tar.gz.

Root cause:
Celery did not have a Docker-reachable MEDIA_URL and fell back to the legacy localhost:8001 default.

Fix:
Set celery MEDIA_URL to http://nginx/s3builds/ in docker-compose.yml so package tarball downloads go through the Docker-reachable nginx route.

Verification:
- Confirmed celery was generating localhost:8001 package dependency URLs before the fix.
- Reproduced npm install failure inside the celery container with ECONNREFUSED.
- Recreated celery with MEDIA_URL=http://nginx/s3builds/.
- Confirmed celery then generated nginx-based dependency URLs.
- Re-ran npm install inside celery against the generated package URL and verified it succeeded.

Closes #19  