### PR TITLE
Hide redundant Repo Sync auth outside localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,50 @@ docker compose up
 # Open http://localhost:8080 and register an account
 ```
 
+### Test GitHub Repo Sync locally
+
+The `GitHub Repo Sync` card changes based on `PUBLIC_URL`, not the browser hostname.
+
+To verify the localhost behavior:
+
+```bash
+PUBLIC_URL=http://localhost:8080 docker compose up -d --build --force-recreate web nginx
+# Open http://localhost:8080/ide/settings
+```
+
+Expected in `GitHub Repo Sync`: `Install GitHub app` and `Link your GitHub account`.
+
+To complete the localhost GitHub Repo Sync flow:
+
+1. In the localhost `GitHub Repo Sync` card, click `Install GitHub app`.
+2. Complete the GitHub App installation in GitHub.
+3. After installation, GitHub currently redirects to the production callback URL instead of back to localhost.
+4. Close that production tab or window.
+5. Return to your existing localhost `Settings` page and click `Link your GitHub account` in the `GitHub Repo Sync` card to complete the local auth step.
+
+In short: on localhost, `Install GitHub app` handles the GitHub-side installation, then `Link your GitHub account` finishes the local CloudPebble auth flow.
+
+In production, the `Install GitHub app` button handles the full Repo Sync flow: it installs the GitHub App, authorizes it, and redirects back to the production `Settings` page with the user linked for `GitHub Repo Sync`.
+
+To verify the prod-like behavior locally:
+
+```bash
+PUBLIC_URL=http://prod-preview:8080 docker compose up -d --build --force-recreate web nginx
+# Open http://localhost:8080/ide/settings
+```
+
+Expected in `GitHub Repo Sync`: `Install GitHub app` only.
+
+This prod-like mode is for checking button visibility only. Do not click the GitHub buttons in this mode unless that non-local `PUBLIC_URL` is actually reachable.
+
+You can confirm the running value with:
+
+```bash
+docker compose exec web /usr/local/bin/python manage.py shell -c "from django.conf import settings; import urllib.parse; print(settings.PUBLIC_URL); print(urllib.parse.urlsplit(settings.PUBLIC_URL).hostname)"
+```
+
+Use a hard refresh or private window if the old button state is still shown.
+
 For HTTPS behind a reverse proxy:
 
 ```bash

--- a/cloudpebble/ide/templates/ide/settings.html
+++ b/cloudpebble/ide/templates/ide/settings.html
@@ -72,10 +72,12 @@
                     <input type="submit" class="btn" value="{% trans 'Install GitHub app' %}">
                     {% csrf_token %}
                 </form>
+                {% if show_github_repo_sync_manual_auth %}
                 <form method="post" action="{% url 'ide:start_github_repo_sync_auth' %}" class="github-action">
                     <input type="submit" class="btn btn-primary" value="{% trans 'Link your GitHub account' %}">
                     {% csrf_token %}
                 </form>
+                {% endif %}
                 {% endif %}
                 </div>
                 <p class="github-help">{% trans 'Used for linking projects to GitHub repositories and push/pull sync.' %}</p>

--- a/cloudpebble/ide/tests/test_github_repo_sync.py
+++ b/cloudpebble/ide/tests/test_github_repo_sync.py
@@ -318,5 +318,15 @@ class TestGithubRepoSync(SimpleTestCase):
         response = settings_page(request)
 
         self.assertContains(response, 'Install GitHub app')
-        self.assertContains(response, 'Link your GitHub account')
+        self.assertContains(response, 'Link your GitHub account', count=2)
+        self.assertContains(response, 'target="_blank"')
+
+    @override_settings(PUBLIC_URL='https://cloudpebble.example.com/')
+    def test_settings_page_hides_manual_repo_sync_auth_for_non_local_public_url(self):
+        request = self._request('get', '/ide/settings', FakeUser(), with_messages=True)
+
+        response = settings_page(request)
+
+        self.assertContains(response, 'Install GitHub app')
+        self.assertContains(response, 'Link your GitHub account', count=1)
         self.assertContains(response, 'target="_blank"')

--- a/cloudpebble/ide/views/settings.py
+++ b/cloudpebble/ide/views/settings.py
@@ -29,6 +29,7 @@ def settings_page(request):
         github_repo_sync = request.user.github_repo_sync
     except UserGithubRepoSync.DoesNotExist:
         github_repo_sync = None
+    show_github_repo_sync_manual_auth = urllib.parse.urlsplit(settings.PUBLIC_URL).hostname in ('localhost', '127.0.0.1')
 
     if request.method == 'POST':
         form = SettingsForm(request.POST, instance=user_settings)
@@ -40,6 +41,7 @@ def settings_page(request):
                 'saved': True,
                 'github_dev': github_dev,
                 'github_repo_sync': github_repo_sync,
+                'show_github_repo_sync_manual_auth': show_github_repo_sync_manual_auth,
             })
 
     else:
@@ -52,6 +54,7 @@ def settings_page(request):
         'saved': False,
         'github_dev': github_dev,
         'github_repo_sync': github_repo_sync,
+        'show_github_repo_sync_manual_auth': show_github_repo_sync_manual_auth,
     })
 
 


### PR DESCRIPTION
In production, the Repo Sync install flow already installs the GitHub App, authorizes Repo Sync, and returns the user to Settings with the account linked. Showing a separate "Link your GitHub account" button there is redundant and suggests a second step that is not needed.

Keep that button on localhost, where the install flow still returns to the production callback and local testing must finish auth manually. Add tests for both render paths and document the local and production behavior in the README.