### PR TITLE
Fix resource build failures for subdirectory paths, cross-kind prefixes

### DIFF
--- a/cloudpebble/ide/models/files.py
+++ b/cloudpebble/ide/models/files.py
@@ -57,6 +57,9 @@ class ResourceFile(IdeModel):
             abs_target = "%s/%s%s%s" % (path, filename_parts[0], variant.get_tags_string(), filename_parts[1])
             if not abs_target.startswith(path):
                 raise Exception(_("Suspicious filename: %s") % self.file_name)
+            abs_target_dir = os.path.dirname(abs_target)
+            if not os.path.exists(abs_target_dir):
+                os.makedirs(abs_target_dir)
             variant.copy_to_path(abs_target)
 
     def save(self, *args, **kwargs):

--- a/cloudpebble/ide/tasks/archive.py
+++ b/cloudpebble/ide/tasks/archive.py
@@ -255,16 +255,18 @@ def do_import_archive(project_id, archive, delete_project=False):
                         file_exists_for_root[root_file_name] = False
 
                     # Create ResourceFile rows in manifest order so generated manifests preserve declared media order.
+                    # Collect all DIR_MAP prefixes (e.g. "images/", "fonts/", "data/").
+                    all_dir_prefixes = set(v + '/' for v in ResourceFile.DIR_MAP.values())
                     for root_file_name, resource_info in desired_resources.items():
-                        # Strip the DIR_MAP prefix (e.g. "images/", "fonts/", "data/") if present,
-                        # since get_path() re-adds it. Keep any further subdirectory structure
-                        # to preserve uniqueness (e.g. "weather/medium/icon.pdc" vs "weather/small/icon.pdc").
-                        kind = resource_info['kind']
-                        dir_prefix = ResourceFile.DIR_MAP.get(kind, '') + '/'
-                        if root_file_name.startswith(dir_prefix):
-                            file_name = root_file_name[len(dir_prefix):]
-                        else:
-                            file_name = root_file_name
+                        # Strip whichever DIR_MAP prefix the path actually starts with,
+                        # since get_path() re-adds the prefix for the resource's kind.
+                        # The manifest path may use a different prefix than the kind implies
+                        # (e.g. a "raw" resource at "images/foo.pdc").
+                        file_name = root_file_name
+                        for prefix in all_dir_prefixes:
+                            if root_file_name.startswith(prefix):
+                                file_name = root_file_name[len(prefix):]
+                                break
                         resources_files[root_file_name] = ResourceFile.objects.create(
                             project=project,
                             file_name=file_name,


### PR DESCRIPTION
Two bugs caused build failures for resources in subdirectories (#26):

1. Import prefix stripping was kind-based, not path-based. A "raw" resource at "images/root_screen/pony.pdc" kept the "images/" prefix (since kind=raw looks for "data/"), then get_path() prepended "data/" producing "data/images/root_screen/pony.pdc". Now strips whichever DIR_MAP prefix the path actually starts with.

2. Build assembly never created intermediate subdirectories, so writing to e.g. "images/icons/menu_icon.png" failed because "icons/" didn't exist. Now creates subdirectories via os.makedirs.

Fixes #26