### PR TITLE
Show emulator models

### DIFF
--- a/cloudpebble/ide/static/ide/css/ide.css
+++ b/cloudpebble/ide/static/ide/css/ide.css
@@ -657,13 +657,25 @@ table.kv-table .kv-remove {
     margin: 0 2px;
 }
 
-.compilation-pane .compilation-buttons.seven-buttons .btn {
+.compilation-pane .compilation-buttons.seven-buttons {
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+}
+
+.compilation-pane .compilation-buttons.seven-buttons > div {
     width: 77px;
-    margin: 0 2px;
 }
 
 .compilation-pane .compilation-buttons .btn:last-child {
     margin-right: 0;
+}
+
+.compilation-pane .compilation-buttons .info {
+    display: block;
+    padding-top: 2px;
+    font-size: 13px;
+    text-align: center;
 }
 
 .compilation-pane h3 {

--- a/cloudpebble/ide/templates/ide/project/compile.html
+++ b/cloudpebble/ide/templates/ide/project/compile.html
@@ -44,13 +44,36 @@
                     <div id="run-qemu" class="tab-pane active">
                         <hr>
                         <div class="compilation-buttons seven-buttons">
-                            <button class="btn btn-primary" id="install-in-qemu-aplite-btn" data-platform="aplite">Aplite</button>
-                            <button class="btn btn-primary" id="install-in-qemu-basalt-btn" data-platform="basalt">Basalt</button>
-                            <button class="btn btn-primary" id="install-in-qemu-chalk-btn" data-platform="chalk">Chalk</button>
-                            <button class="btn btn-primary" id="install-in-qemu-diorite-btn" data-platform="diorite">Diorite</button>
-                            <button class="btn btn-primary" id="install-in-qemu-emery-btn" data-platform="emery">Emery</button>
-                            <button class="btn btn-primary" id="install-in-qemu-flint-btn" data-platform="flint">Flint</button>
-                            <button class="btn btn-primary" id="install-in-qemu-gabbro-btn" data-platform="gabbro">Gabbro</button>
+                            <div>
+                                <button class="btn btn-primary" id="install-in-qemu-aplite-btn" data-platform="aplite">Aplite</button>
+                                <div class="info">Classic</div>
+                                <div class="info">Steel</div>
+                            </div>
+                            <div>
+                                <button class="btn btn-primary" id="install-in-qemu-basalt-btn" data-platform="basalt">Basalt</button>
+                                <div class="info">Time</div>
+                                <div class="info">Time Steel</div>
+                            </div>
+                            <div>
+                                <button class="btn btn-primary" id="install-in-qemu-chalk-btn" data-platform="chalk">Chalk</button>
+                                <div class="info">Time Round</div>
+                            </div>
+                            <div>
+                                <button class="btn btn-primary" id="install-in-qemu-diorite-btn" data-platform="diorite">Diorite</button>
+                                <div class="info">Pebble 2</div>
+                            </div>
+                            <div>
+                                <button class="btn btn-primary" id="install-in-qemu-emery-btn" data-platform="emery">Emery</button>
+                                <div class="info">Time 2</div>
+                            </div>
+                            <div>
+                                <button class="btn btn-primary" id="install-in-qemu-flint-btn" data-platform="flint">Flint</button>
+                                <div class="info">Pebble 2 Duo</div>
+                            </div>
+                            <div>
+                                <button class="btn btn-primary" id="install-in-qemu-gabbro-btn" data-platform="gabbro">Gabbro</button>
+                                <div class="info">Round 2</div>
+                            </div>
                         </div>
                         <hr>
                         <div class="compilation-buttons two-buttons">


### PR DESCRIPTION
Display corresponding watch models below emulator platform buttons.

I don't do Pebble development that often, so haven't memorized the "codenames" for each watch model. Thought it would be helpful to show the models below the emulator buttons.

<img width="976" height="482" alt="screenshot-2026-04-04_18-06-16" src="https://github.com/user-attachments/assets/62ccbc68-0623-4f81-b4ce-8d0f2f994d97" />


