### PR TITLE
Fix pebble.h not found for gabbro/flint in IDE code completion

### DIFF
--- a/cloudpebble-ycmd-proxy/Dockerfile
+++ b/cloudpebble-ycmd-proxy/Dockerfile
@@ -33,11 +33,15 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
   && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
   && rm "node-v$NODE_VERSION-linux-x64.tar.gz"
 
-# Pebble SDK 4.3 (for include headers only)
-ENV SDK_THREE_VERSION=4.3
-RUN mkdir /sdk3 && \
-  curl -L "https://github.com/aveao/PebbleArchive/raw/master/SDKCores/sdk-core-$SDK_THREE_VERSION.tar.bz2" | \
-  tar --strip-components=1 -xj -C /sdk3
+# Pebble SDK (for include headers only – must match the version used by the
+# build system so that YCM sees headers for all supported platforms including
+# gabbro and flint).
+RUN SDK_INFO=$(curl -sf https://sdk.repebble.com/v1/files/sdk-core/4.9.148) && \
+  SDK_URL=$(echo "$SDK_INFO" | python3 -c "import sys,json; print(json.load(sys.stdin)['url'])") && \
+  curl -Lf "$SDK_URL" -o /tmp/sdk.tar.gz && \
+  mkdir -p /sdk3 && \
+  tar xzf /tmp/sdk.tar.gz -C /sdk3 --strip-components=1 "sdk-core/" && \
+  rm /tmp/sdk.tar.gz
 
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/scripts/update_sdk_version.py
+++ b/scripts/update_sdk_version.py
@@ -21,6 +21,7 @@ PROJECT_MODEL = ROOT / "cloudpebble" / "ide" / "models" / "project.py"
 FILES_TO_UPDATE = [
     ROOT / "cloudpebble" / "Dockerfile",
     ROOT / "cloudpebble-qemu-controller" / "Dockerfile",
+    ROOT / "cloudpebble-ycmd-proxy" / "Dockerfile",
     ROOT / "cloudpebble" / "ide" / "api" / "project.py",
     ROOT / "cloudpebble" / "ide" / "models" / "project.py",
     ROOT / "cloudpebble" / "ide" / "tasks" / "gist.py",
@@ -74,7 +75,10 @@ def update_version_strings(current_version: str, new_version: str) -> list[Path]
         if path == ROOT / "cloudpebble" / "Dockerfile":
             new = re.sub(r"RUN pebble sdk install [^\s]+", f"RUN pebble sdk install {new_version}", new)
             new = re.sub(r"RUN pebble sdk activate [^\s]+", f"RUN pebble sdk activate {new_version}", new)
-        elif path == ROOT / "cloudpebble-qemu-controller" / "Dockerfile":
+        elif path in (
+            ROOT / "cloudpebble-qemu-controller" / "Dockerfile",
+            ROOT / "cloudpebble-ycmd-proxy" / "Dockerfile",
+        ):
             new = re.sub(
                 r"https://sdk\.repebble\.com/v1/files/sdk-core/[^\s)]+",
                 f"https://sdk.repebble.com/v1/files/sdk-core/{new_version}",


### PR DESCRIPTION
The YCM proxy was using SDK 4.3 from PebbleArchive for include headers,
which predates gabbro and flint platform support. Updated to download
SDK 4.9.148 from sdk.repebble.com (matching the build system) so that
all platform include directories are available.

Also added the YCM proxy Dockerfile to update_sdk_version.py so future
SDK version bumps keep it in sync automatically.

Fixes: https://forum.repebble.com/t/cloudpebble-include-pebble-h-not-found/469

https://claude.ai/code/session_01XykC5pesnNRRJPE51u73N3