### PR TITLE
Block http for all browsers

### DIFF
--- a/cloudpebble/ide/templates/ide/qemu-sensors.html
+++ b/cloudpebble/ide/templates/ide/qemu-sensors.html
@@ -25,6 +25,14 @@
         }, 250);
         var isAndroid = /Android/i.test(navigator.userAgent);
 
+        // DeviceMotion/Orientation events are blocked on insecure origins (http://) for all major browsers 
+	// (see https://w3c.github.io/deviceorientation).
+        if(!window.isSecureContext) {
+            $('.state').text("Sensors are blocked on insecure origins. Open this page over HTTPS (or localhost) and retry.");
+            $('.stuff').hide();
+            return;
+        }
+
         var attachSensorHandlers = function() {
             window.ondevicemotion = _.throttle(function(e) {
                 if(!e.accelerationIncludingGravity) {
@@ -59,12 +67,7 @@
         };
 
         var showBlockedSensorsState = function() {
-            var secure = window.isSecureContext || location.protocol === 'https:' || location.hostname === 'localhost' || location.hostname === '127.0.0.1';
-            if(!secure) {
-                $('.state').text("Sensors are blocked on insecure origins. Open this page over HTTPS (or localhost) and retry.");
-            } else {
-                $('.state').text("Sensors are blocked. Allow motion/orientation permission when prompted and retry.");
-            }
+            $('.state').text("Sensors are blocked. Allow motion/orientation permission when prompted and retry.");
             $('.stuff').hide();
             $('.enable-sensors').show();
         };


### PR DESCRIPTION
Note: Up to the maintainers whether they want this.

[PR#40 ](https://github.com/coredevices/cloudpebble/pull/40) introduced an error message when users attempt to forward sensor data over HTTP, but only for browsers that request the sensor runtime permission (iOS / Safari 13+). This was intended to surface a previously silent failure.

However, as of ~2019, all major browsers block access to sensor APIs on non-HTTPS origins, regardless of whether they prompt for runtime permission. Users on non-iOS/Safari browsers who try to use IMU forwarding over HTTP will still fail silently.

This PR broadens the HTTPS check so the error is shown to all users, not just those on permission-gating browsers (i.e. iOS 13+ w/Safari). This guides anyone hitting the issue toward using HTTPS.

## Trade-off

This could unnecessarily block users on homemade or pre-2019 browsers that don't enforce the HTTPS requirement for sensor access. Given how narrow that audience is, the improved UX for the common case seems worth the trade-off, but leaving this to reviewer discretion.

## Testing 
 
### Test Setup
 
**Environment**
- Host: Ubuntu 22.04.5 LTS, home WiFi
- CloudPebble configured with `PUBLIC_URL` and `ENABLE_SSL` (see configurations below)
 
**Test App**
Added a minimal [IMU Test App](https://github.com/amwatson/Pebble-IMU-Test-App) to validate sensor forwarding end-to-end. Run via the CloudPebble emulator.
 
**Pairing Flow**
1. Start the Test App inside the CloudPebble emulator and click Settings->Sensors to generate a pairing code
2. On the test device, navigate to `[PUBLIC_URL]/ide/emulator/token` and enter the code
 
---
 
### Devices & Browsers
 
| Device | OS | Browser |
|---|---|---|
| iPhone 14 Pro | iOS 26.3.1 | Safari |
| Leia Lumepad 2 | Android | Chrome 137.0.7151.115 |
 
---
 
### Test Cases
 
**HTTP** (`PUBLIC_URL=http://[PC_IP]:8080`, `ENABLE_SSL=no`)
 
| Platform | Result |
|---|---|
| iOS | "Sensors are blocked on insecure origins. Open this page over HTTPS (or localhost) and retry." |
| Android | "Sensors are blocked on insecure origins. Open this page over HTTPS (or localhost) and retry." |

 
**HTTPS** (`PUBLIC_URL=https://[tunnel_IP]:8080`, `ENABLE_SSL=yes`)
 
| Platform | Result |
|---|---|
| iOS | User prompted to accept permission. If accepted, Browser streams acceleration + heading; Test App reflects matching values. If user denies prompt, "Sensors are blocked. Allow motion/orientation permission when prompted and retry."  |
| Android | Browser streams acceleration + heading; Test App reflects matching values |
