### PR TITLE
Fix data-loss bug in github_pull wipe-then-import

### DIFF
--- a/cloudpebble/ide/tasks/git.py
+++ b/cloudpebble/ide/tasks/git.py
@@ -15,11 +15,12 @@ from github import Github, GithubException, InputGitTreeElement
 
 from ide.git import git_auth_check, get_github
 from ide.models.build import BuildResult
+from ide.models.files import SourceFile
 from ide.models.project import Project
 from ide.tasks import do_import_archive, run_compile
 from ide.utils.git import git_sha, git_blob
-from ide.utils.project import find_project_root_and_manifest, BaseProjectItem, InvalidProjectArchiveException
-from ide.utils.sdk import generate_manifest_dict, generate_manifest, generate_wscript_file, manifest_name_for_project
+from ide.utils.project import find_project_root_and_manifest, BaseProjectItem, InvalidProjectArchiveException, MANIFEST_KINDS
+from ide.utils.sdk import generate_manifest_dict, generate_manifest, generate_wscript_file, load_manifest_dict, manifest_name_for_project
 from utils.td_helper import send_td_event
 
 __author__ = 'katharine'
@@ -345,27 +346,85 @@ def github_pull(user, project):
         root, manifest_item = find_project_root_and_manifest([GitProjectItem(repo, x) for x in tree.tree])
     except ValueError as e:
         raise ValueError("In manifest file: %s" % str(e))
-    resource_root = root + project.resources_path + '/'
-    manifest = json.loads(manifest_item.read())
 
-    media = manifest.get('resources', {}).get('media', [])
-    project_type = manifest.get('projectType', 'native')
+    # Parse the manifest the same way do_import_archive does so we make our
+    # pre-flight decisions on the same data the import will use. Reading
+    # manifest.get('resources') / manifest.get('projectType') directly is
+    # wrong for package.json (those live under manifest['pebble']) — the
+    # original code had this bug, which silently disabled the per-resource
+    # existence check below for every package.json project.
+    raw_manifest = json.loads(manifest_item.read())
+    manifest_kind = next((k for k in MANIFEST_KINDS if manifest_item.path.endswith(k)), None)
+    try:
+        manifest_project_options, media, _deps = load_manifest_dict(raw_manifest, manifest_kind)
+    except (InvalidProjectArchiveException, KeyError, ValueError, TypeError) as e:
+        raise Exception("Could not read manifest on branch '%s': %s" % (branch_name, e))
+    incoming_project_type = manifest_project_options.get('project_type', 'native')
+
+    # resources_path depends on the INCOMING project type, not the current
+    # one — a pull can legitimately change the project type.
+    incoming_resources_path = 'src/resources' if incoming_project_type == 'package' else 'resources'
+    resource_root = root + incoming_resources_path + '/'
 
     for resource in media:
         path = resource_root + resource['file']
-        if project_type == 'pebblejs' and resource['name'] in {
+        if incoming_project_type == 'pebblejs' and resource['name'] in {
             'MONO_FONT_14', 'IMAGE_MENU_ICON', 'IMAGE_LOGO_SPLASH', 'IMAGE_TILE_SPLASH'}:
             continue
         if path not in paths_notags:
             raise Exception("Resource %s not found in repo." % path)
 
+    # Refuse to wipe if the incoming tree has NOTHING importable — no
+    # resources in the manifest AND no source files at any path
+    # SourceFile.get_details_for_path would accept for this project type.
+    # This is the forum-reported failure mode
+    # (https://forum.repebble.com/t/cloudpebble-didnt-use-pull-correctly-from-github/829):
+    # the user pulled from a branch where they'd only uploaded the compiled
+    # .pbw + screenshots via the GitHub web UI, with a package.json whose
+    # `pebble.resources.media` was []. All checks above passed, the wipe
+    # happened, and do_import_archive silently imported zero files.
+    #
+    # This has to fire BEFORE touching the DB: SourceFile/ResourceVariant
+    # post_delete signals flush S3 blobs synchronously, so a later DB
+    # transaction rollback would restore rows pointing at deleted blobs.
+    if project.source_files.exists() or project.resources.exists():
+        has_importable_source = False
+        for tree_path in paths:
+            if not tree_path.startswith(root):
+                continue
+            try:
+                SourceFile.get_details_for_path(incoming_project_type, tree_path[len(root):])
+            except (ValueError, KeyError):
+                continue
+            has_importable_source = True
+            break
+        if not media and not has_importable_source:
+            raise Exception(
+                "Refusing to pull from '%s': the branch has no resources in "
+                "its manifest and no source files the importer recognises. "
+                "Pulling would empty your project. Double-check that you're "
+                "pulling from the right branch." % branch_name
+            )
+
     # Fully download and validate the archive BEFORE touching the database, so
-    # an empty/truncated/corrupt stream from GitHub fails loudly without wiping.
-    zip_url = repo.get_archive_link('zipball', branch_name)
+    # an empty/truncated/corrupt stream from GitHub fails loudly without
+    # wiping. Pin the download to the commit SHA we just validated so a
+    # branch update between the tree fetch and the archive fetch can't slip a
+    # different tree past us.
+    zip_url = repo.get_archive_link('zipball', branch.commit.sha)
     with urlopen(zip_url, timeout=30) as response:
         archive_bytes = response.read()
     if not archive_bytes or not zipfile.is_zipfile(BytesIO(archive_bytes)):
         raise Exception("GitHub returned an invalid archive for branch '%s'." % branch_name)
+
+    # Snapshot the pre-pull row counts so we can detect a "successful" import
+    # that silently produced an empty project. Forum-reported failure mode:
+    # the configured branch had a valid package.json with an empty media list
+    # and no recognised src/ layout, so do_import_archive succeeded with zero
+    # source files and zero resources. Without this check the wipe would
+    # commit and the user's project would be blank with no UI recovery path.
+    had_source_files = project.source_files.exists()
+    had_resources = project.resources.exists()
 
     # Wipe + import in a single transaction. do_import_archive opens its own
     # atomic block, which becomes a savepoint nested inside ours; any failure
@@ -381,6 +440,21 @@ def github_pull(user, project):
         project.resources.all().delete()
 
         import_result = do_import_archive(project.id, archive_bytes)
+
+        # Guard against the "import succeeded but produced nothing" case
+        # described above. If the user had a real project before and the pull
+        # would leave them with no source files and no resources, refuse to
+        # commit so the wipe rolls back and they can investigate (wrong
+        # branch configured, manifest with empty media, src/ layout the
+        # importer doesn't recognise, etc).
+        if (had_source_files or had_resources) and \
+                not project.source_files.exists() and not project.resources.exists():
+            raise Exception(
+                "Pull from '%s' would empty the project (no source files or "
+                "resources were imported). Aborting to protect your work — "
+                "check that the branch contains a valid Pebble project with "
+                "src/ files and a manifest that lists its resources." % branch_name
+            )
 
         # Only advance the commit pointer after a successful import. If we
         # advanced it earlier and the import failed, the next pull would see

--- a/cloudpebble/ide/tasks/git.py
+++ b/cloudpebble/ide/tasks/git.py
@@ -1,11 +1,14 @@
 import base64
+from io import BytesIO
 from urllib.request import urlopen, Request
 from urllib.error import URLError, HTTPError
 import json
 import os
 import logging
+import zipfile
 
 from celery import shared_task
+from django.db import transaction
 from django.utils.timezone import now
 from github.GithubObject import NotSet
 from github import Github, GithubException, InputGitTreeElement
@@ -356,21 +359,41 @@ def github_pull(user, project):
         if path not in paths_notags:
             raise Exception("Resource %s not found in repo." % path)
 
-    # Now we grab the zip.
+    # Fully download and validate the archive BEFORE touching the database, so
+    # an empty/truncated/corrupt stream from GitHub fails loudly without wiping.
     zip_url = repo.get_archive_link('zipball', branch_name)
-    u = urlopen(zip_url)
+    with urlopen(zip_url, timeout=30) as response:
+        archive_bytes = response.read()
+    if not archive_bytes or not zipfile.is_zipfile(BytesIO(archive_bytes)):
+        raise Exception("GitHub returned an invalid archive for branch '%s'." % branch_name)
 
-    # And wipe the project!
-    # TODO: transaction support for file contents would be nice...
-    project.source_files.all().delete()
-    project.resources.all().delete()
+    # Wipe + import in a single transaction. do_import_archive opens its own
+    # atomic block, which becomes a savepoint nested inside ours; any failure
+    # there propagates and rolls the delete back, so the project DB rows
+    # survive. Note: S3/local file blobs are deleted by a post_delete signal
+    # and are NOT covered by the transaction, so we keep the validation above
+    # (and the manifest/resource pre-checks earlier) to make a partial wipe
+    # extremely unlikely. A failure inside do_import_archive after the wipe
+    # would leave orphaned/empty blobs — an acceptable trade-off vs the
+    # previous behaviour of nuking the whole project with no recovery.
+    with transaction.atomic():
+        project.source_files.all().delete()
+        project.resources.all().delete()
 
-    # This must happen before do_import_archive or we'll stamp on its results.
-    project.github_last_commit = branch.commit.sha
-    project.github_last_sync = now()
-    project.save()
+        import_result = do_import_archive(project.id, archive_bytes)
 
-    import_result = do_import_archive(project.id, u.read())
+        # Only advance the commit pointer after a successful import. If we
+        # advanced it earlier and the import failed, the next pull would see
+        # github_last_commit == branch head and return False ("nothing to do"),
+        # leaving the user stuck with a blank project and no way to recover
+        # via the UI.
+        #
+        # update_fields so we don't clobber project fields (e.g. project_type,
+        # app_keys, dependencies) that do_import_archive just wrote via its own
+        # Project instance — our `project` here is stale.
+        project.github_last_commit = branch.commit.sha
+        project.github_last_sync = now()
+        project.save(update_fields=['github_last_commit', 'github_last_sync'])
 
     send_td_event('cloudpebble_github_pull', data={
         'data': {


### PR DESCRIPTION
## Summary

Fixes a data-loss bug in CloudPebble's "Pull from GitHub". A user (forum + email confirmed) clicked Pull, the project went blank, and there was no UI path to recover. Production Railway logs for the 6h window show 27 `do_github_pull` celery tasks — all "succeeded". This isn't a crash; it's a happy-path bug where a "successful" import silently produces an empty project.

## The user's exact failure mode

1. Created `test-backup-branch` on his repo and used GitHub's "Add files via upload" web UI to push what he thought was a backup. He only uploaded the compiled `.pbw`, a backup zip, README, `package.json`, `index.js`, `config.json`, two PNG screenshots — **no `src/`, no `resources/`**.
2. The uploaded `package.json` had a valid `"pebble"` block but with `"resources": {"media": []}` — empty.
3. Days later, while working in CloudPebble, he broke something and hit "Pull" expecting his "backup" to restore him. The pull fetched that branch.
4. `github_pull` ran:
   - `find_project_root_and_manifest` accepted `package.json` (valid pebble block).
   - Per-resource existence check iterated empty `media` — never raised.
   - Wiped his source files + resources.
   - Advanced `github_last_commit` to the new head.
   - `do_import_archive` walked the zip, found no `src/c/`, no `src/pkjs/`, no `resources/` — silently imported 0 of everything. Returned `True`.
5. Result: blank IDE. Retrying "Pull" returned `False` ("nothing to do") because the commit pointer already matched. *"It deleted everything... It brought nothing back."*

Not a recent regression — the wipe-then-import pattern predates all recent work (last touch to this file `04b9317`, 2026-03-19, only modified push).

## Fix — three layers, in order

1. **Pre-flight (new)** — *the only layer that actually saves the reported user*. Before any DB or S3 mutation: if the project has files, AND the manifest has empty `media`, AND no path in the tree matches `SourceFile.get_details_for_path` for the incoming project type → raise with a clear "wrong branch?" message. This matters because `SourceFile`/`ResourceVariant` `post_delete` signals flush S3 blobs synchronously, so a later DB transaction rollback would restore rows pointing at deleted blobs.
2. **Atomic transaction** around wipe + import + commit-pointer save. `do_import_archive` opens its own atomic block which becomes a savepoint nested inside ours; exceptions there roll back the wipe (DB-only — see note above).
3. **Post-import zero-check** inside the transaction as a backstop.

Plus several correctness fixes codex caught:

- **Pre-existing manifest-parsing bug**: the original code read `manifest.get('resources', ...)` and `manifest.get('projectType', ...)` at the root, but `package.json` nests these under `manifest['pebble']`. The per-resource existence check has been silently disabled for every `package.json` project. Now uses `load_manifest_dict` — the same parser `do_import_archive` uses — so pre-flight and import agree.
- `resources_path` was computed from the *current* project type; should come from the *incoming* manifest (a pull can change type).
- Archive download was keyed on `branch_name`, racing branch updates between the tree fetch and the zip fetch. Now pinned to `branch.commit.sha`.
- `github_last_commit` save moved to **after** the import (was before) so a failed import doesn't poison retries.
- `project.save(update_fields=['github_last_commit', 'github_last_sync'])` so we don't clobber project fields the import just wrote on its own `Project` instance — ours is stale.
- `urlopen` now uses a context manager with a 30s timeout.
- `zipfile.is_zipfile(...)` check before any wipe.

## Known limitation (documented inline)

S3/local blob deletes happen via `post_delete` synchronously and aren't part of the DB transaction. The pre-flight catches the reported failure mode before any wipe. If a future failure mode slips past the pre-flight and triggers the post-import zero-check or an exception inside `do_import_archive`, DB rows roll back but blobs are gone — restored rows would point at deleted blobs. A fully transactional fix would use `transaction.on_commit()` for blob deletes or import into replacement rows before deleting old ones; left as a TODO since the pre-flight covers the known failure.

## Test plan

- [ ] Pull from a branch that matches the current project structure — files import, `github_last_commit` advances.
- [ ] Reproduce Andrew's case: point a project at a branch with a `package.json` containing `pebble.resources.media: []` and no `src/`. Confirm pull raises with the "wrong branch?" message *before* touching anything, project files survive, `github_last_commit` does not advance.
- [ ] Same setup but with `appinfo.json` instead — confirm the manifest_kind detection works for both kinds.
- [ ] `package.json` project with non-empty `pebble.resources.media` — confirm the per-resource existence check now actually runs (was silently disabled before this PR).
- [ ] Force `do_import_archive` to raise mid-flight — confirm DB rows roll back, `github_last_commit` does not advance.
- [ ] Pull a project that changes `projectType` (e.g. native → package) — confirm the new `resources_path` is used for validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)