### PR TITLE
Place configure popover to bottom

### DIFF
--- a/cloudpebble/ide/static/ide/js/emulator.js
+++ b/cloudpebble/ide/static/ide/js/emulator.js
@@ -157,7 +157,7 @@ CloudPebble.Emulator = new (function() {
 
     this.init = function() {
         self.element = $('#emulator-container .configure').popover({
-            placement: 'right',
+            placement: 'bottom',
             trigger: 'click',
             content: getHTML,
             html: true,


### PR DESCRIPTION
This fixes issue #47 .

On emery, the charging, bluetooth and 24-hour checkboxes seem to be hijacked by the emulator canvas. By repositioning the popover this no longer happens.

It might need some repositioning to look nice, but I'm not that familiar with where everything is located.