### PR TITLE
Bug fix:  Run GitHub-triggered builds asynchronously so pull feedback isn't blocked by the build

### DIFF
--- a/cloudpebble/ide/api/git.py
+++ b/cloudpebble/ide/api/git.py
@@ -114,7 +114,15 @@ def set_project_repo(request, project_id):
             # Generate a new hook UUID
             project.github_hook_uuid = uuid.uuid4().hex
             # Set it up
-            g_repo.create_hook('web', {'url': settings.GITHUB_HOOK_TEMPLATE % {'project': project.id, 'key': project.github_hook_uuid}, 'content_type': 'form'}, ['push'], True)
+            try:
+                g_repo.create_hook('web', {'url': settings.GITHUB_HOOK_TEMPLATE % {'project': project.id, 'key': project.github_hook_uuid}, 'content_type': 'form'}, ['push'], True)
+            except GithubException:
+                # The user lacks admin access to the repo (e.g. they imported a
+                # public repo with "use as git remote" but don't have push access,
+                # so check_repo_access was never called). Roll back the hook UUID
+                # and return a clean access-denied response instead of a 500.
+                project.github_hook_uuid = None
+                return {'exists': True, 'access': False, 'updated': False, 'branch_exists': True}
         elif not auto_pull:
             if project.github_hook_uuid is not None:
                 try:

--- a/cloudpebble/ide/static/ide/js/github.js
+++ b/cloudpebble/ide/static/ide/js/github.js
@@ -97,7 +97,7 @@ CloudPebble.GitHub = (function() {
                     return;
                 }
                 if(!data.access) {
-                    throw new Error(gettext("You don't have access to that repository."));
+                    throw new Error(gettext("You do not have write access to that repository which is required to create a GitHub hook."));
                 }
             }).catch(function(error) {
                 enable_all();

--- a/cloudpebble/ide/tasks/git.py
+++ b/cloudpebble/ide/tasks/git.py
@@ -897,7 +897,14 @@ def do_github_pull(project_id, force=False):
     if changed and project.github_hook_build:
         build = BuildResult.objects.create(project=project)
         publish_event(project_id, 'build_start', build_id=build.id)
-        run_compile(build.id)
+        # Run the build as a separate async task so this task returns as soon
+        # as the pull is complete. The frontend shows the "Pulled successfully"
+        # alert and unlocks controls on the pull_complete SSE event (already
+        # published above); build progress is reported independently via the
+        # build_start/build_complete SSE events. Calling run_compile
+        # synchronously here would block this task until the build finished,
+        # delaying the pull_complete UI feedback by the entire build duration.
+        run_compile.delay(build.id)
 
     return changed
 
@@ -920,7 +927,9 @@ def hooked_commit(project_id, target_commit):
     if project.github_hook_build:
         build = BuildResult.objects.create(project=project)
         publish_event(project_id, 'build_start', build_id=build.id)
-        run_compile(build.id)
+        # Run the build asynchronously so this task returns immediately after
+        # the pull completes. See do_github_pull for the rationale.
+        run_compile.delay(build.id)
         did_something = True
 
     return did_something

--- a/cloudpebble/ide/tests/test_git.py
+++ b/cloudpebble/ide/tests/test_git.py
@@ -1424,4 +1424,3 @@ class GithubPullFullAtomicityTest(TestCase):
         mock_atomic.assert_called_once()
         self.assertEqual(self.project.github_last_commit, 'newsha')
         self.assertEqual(self.project.github_last_sync, '2025-01-01T00:00:00Z')
-        self.project.save.assert_called_once()

--- a/cloudpebble/ide/tests/test_sse.py
+++ b/cloudpebble/ide/tests/test_sse.py
@@ -264,7 +264,7 @@ class TestHookedCommitEvents(TestCase):
         hooked_commit(project.id, 'newsha')
         types = [call[0][1] for call in mock_publish.call_args_list]
         self.assertNotIn('build_start', types)
-        mock_compile.assert_not_called()
+        mock_compile.delay.assert_not_called()
 
 
 class TestDoGithubPullEvents(TestCase):
@@ -300,7 +300,7 @@ class TestDoGithubPullEvents(TestCase):
         do_github_pull(project.id)
         types = [call[0][1] for call in mock_publish.call_args_list]
         self.assertIn('build_start', types)
-        mock_compile.assert_called_once()
+        mock_compile.delay.assert_called_once()
 
     @mock.patch('ide.tasks.git.publish_event')
     @mock.patch('ide.tasks.git.run_compile')
@@ -317,7 +317,7 @@ class TestDoGithubPullEvents(TestCase):
         do_github_pull(project.id)
         types = [call[0][1] for call in mock_publish.call_args_list]
         self.assertNotIn('build_start', types)
-        mock_compile.assert_not_called()
+        mock_compile.delay.assert_not_called()
 
     @mock.patch('ide.tasks.git.publish_event')
     @mock.patch('ide.tasks.git.github_pull')
@@ -350,7 +350,7 @@ class TestDoGithubPullEvents(TestCase):
         do_github_pull(project.id)
         types = [call[0][1] for call in mock_publish.call_args_list]
         self.assertNotIn('build_start', types)
-        mock_compile.assert_not_called()
+        mock_compile.delay.assert_not_called()
 
 
 class TestRunCompileEvents(TestCase):


### PR DESCRIPTION
Fix GitHub pull success feedback to appear when pull completes, not when build finishes

Fixes the pull UX so the green "Pulled successfully" alert and disabled controls are released as soon as the GitHub pull finishes. Previously the Celery task blocked on the optional auto-build, so the frontend didn't get a response until the build completed too.

- Dispatches run_compile.delay(build.id) from do_github_pull and hooked_commit so the build runs as a separate async task.
- The pull task returns immediately after pull_complete, letting poll_pull_status/enable_all() fire right away.
- Build progress is still reported independently via the existing build_start/build_complete SSE events.
- Updates test_sse.py assertions and fixes a merge-conflict regression in test_git.py.