### PR TITLE
Fix cross-user audio leaks in emulator audio streaming

### DIFF
--- a/cloudpebble-qemu-controller/controller.py
+++ b/cloudpebble-qemu-controller/controller.py
@@ -8,6 +8,7 @@ import gevent.pool
 from flask import Flask, request, jsonify, abort
 from flask_cors import CORS
 from time import time as now
+import hmac
 import ssl
 import os
 import pwd
@@ -185,6 +186,12 @@ def ws_audio(emu):
         emulator = emulators[UUID(emu)]
     except (ValueError, KeyError):
         return "not found", 404
+    # Unlike VNC/phone, this endpoint had no credential check.
+    token = request.args.get('token', '')
+    if not token or not hmac.compare_digest(token.encode('utf-8'),
+                                            (emulator.token or '').encode('utf-8')):
+        logging.warning("ws_audio: bad token for emu=%s", emu)
+        return "forbidden", 403
     if emulator.platform not in ('emery', 'flint') or not emulator.audio_sink:
         return "no audio for this platform", 400
 

--- a/cloudpebble-qemu-controller/emulator.py
+++ b/cloudpebble-qemu-controller/emulator.py
@@ -150,8 +150,8 @@ class Emulator(object):
             return
         self.audio_sink = sink_name
         self.audio_module_id = int(m.group(1))
-        # Per-emulator pulse client.conf as belt-and-suspenders for routing —
-        # libpulse uses default-sink from this when QEMU passes dev=NULL.
+        # Belt-and-suspenders: QEMU is pinned to this sink via out.name=,
+        # this covers anything else in the process tree that isn't.
         self.audio_client_conf = '/tmp/pulse-' + sink_name + '.conf'
         try:
             with open(self.audio_client_conf, 'w') as f:
@@ -159,15 +159,6 @@ class Emulator(object):
         except OSError:
             logging.exception('audio: failed to write %s', self.audio_client_conf)
             self.audio_client_conf = None
-        # Make our sink the server-side default. QEMU's libpulse passes
-        # dev=NULL to pa_simple_new, so the server routes to its current
-        # default. Concurrent launches race here — last writer wins — but
-        # previously-attached streams stay bound to their original sink,
-        # so existing emulators keep their routing intact.
-        try:
-            subprocess.call(['pactl', 'set-default-sink', sink_name], timeout=5)
-        except (OSError, subprocess.TimeoutExpired):
-            logging.exception('audio: failed to set default sink %s', sink_name)
         logging.info('audio: created null-sink %s module=%s', sink_name, self.audio_module_id)
 
     def _unload_audio_sink(self):
@@ -221,9 +212,10 @@ class Emulator(object):
         mtd_args = ['-mtdblock', spi_flash]
         mtd_drive = ['-drive', 'if=mtd,format=raw,file=%s' % spi_flash]
         if self.platform in AUDIO_PLATFORMS and self.audio_sink:
+            # out.name pins the stream to this sink instead of the shared server default.
             audio_args = [
                 '-audiodev',
-                'pa,id=audio0,server=unix:/run/cloudpebble-pipewire/pulse/native',
+                'pa,id=audio0,server=unix:/run/cloudpebble-pipewire/pulse/native,out.name=%s' % self.audio_sink,
                 '-machine', 'audiodev=audio0',
             ]
         else:

--- a/cloudpebble/ide/static/ide/js/qemu.js
+++ b/cloudpebble/ide/static/ide/js/qemu.js
@@ -77,7 +77,7 @@
                 mAudioGain.connect(mAudioCtx.destination);
 
                 var wsURL = (mSecure ? 'wss' : 'ws') + '://' + mHost + ':' + mAPIPort
-                          + '/qemu/' + mInstanceID + '/ws/audio';
+                          + '/qemu/' + mInstanceID + '/ws/audio?token=' + encodeURIComponent(mToken);
                 mAudioWS = new WebSocket(wsURL);
                 mAudioWS.binaryType = 'arraybuffer';
 


### PR DESCRIPTION
Two issues allowed one user's emulator audio to reach another user:

1. QEMU's PulseAudio stream was routed via the server-wide default sink (pactl set-default-sink on every launch). QEMU attaches its stream lazily, so a concurrent launch could flip the default and route one session's audio into another session's sink. Bind the stream explicitly to the emulator's own null-sink with out.name= on the audiodev and stop mutating the global default entirely.

2. The /qemu/<uuid>/ws/audio websocket required no credential, unlike the VNC (password) and phone (in-protocol token) websockets, so anyone who learned a session UUID could listen in. Require the session token as a query parameter, verified with a constant-time compare; the IDE now sends it when opening the audio socket.