### PR TITLE
Increase request line limit to 8190 bytes

### DIFF
--- a/cloudpebble/gunicorn.py
+++ b/cloudpebble/gunicorn.py
@@ -8,6 +8,9 @@ workers = int(os.environ.get('WEB_CONCURRENCY', multiprocessing.cpu_count() * 2 
 # and tunable rather than relying on gevent's default of 1000.
 worker_connections = int(os.environ.get('WORKER_CONNECTIONS', 1000))
 timeout = 120
+# Allow larger request lines/headers for big Clay watchface configs saved as JSON.
+# Gunicorn's default of 4094 bytes is too small (see issue: "Request Line is too large").
+limit_request_line = 8190
 
 
 def post_fork(server, worker):


### PR DESCRIPTION
## Problem
Saving a large Clay watchface configuration fails with:

```
Bad Request
Request Line is too large (4374 > 4094)
```

## Root cause
The `web` service is started via `docker_start.sh` with:
```
gunicorn -c gunicorn.py cloudpebble.wsgi --bind 0.0.0.0:$PORT
```
`cloudpebble/gunicorn.py` did not set `limit_request_line`, so Gunicorn fell back to its default of exactly 4094 bytes - matching the error message. The nginx configs (`nginx/nginx.conf`, `nginx/nginx.hetzner.conf`) don't restrict header/request-line size, so Gunicorn is the limiting factor.

## Fix
Explicitly set `limit_request_line = 8190` in `cloudpebble/gunicorn.py` to allow larger request lines/headers, so bigger Clay configs saved as JSON no longer get rejected.
