### PR TITLE
Change default branch name from 'master' to 'main' for GitHub imports…

### DIFF
--- a/cloudpebble/ide/static/ide/js/github.js
+++ b/cloudpebble/ide/static/ide/js/github.js
@@ -63,7 +63,7 @@ CloudPebble.GitHub = (function() {
             var hook_force = pane.find('#github-repo-hook-force').is(':checked');
 
             if(repo_branch == null || repo_branch.length == 0) {
-                repo_branch = "master";
+                repo_branch = "main";
             }
 
             if((new_repo === CloudPebble.ProjectInfo.github.repo || !new_repo && !CloudPebble.ProjectInfo.github.repo) &&

--- a/cloudpebble/ide/static/ide/js/project_list.js
+++ b/cloudpebble/ide/static/ide/js/project_list.js
@@ -184,7 +184,7 @@ $(function() {
             return;
         }
         if(branch.length == 0) {
-            branch = 'master';
+            branch = 'main';
         }
         disable_import_controls();
         active_set.find('.progress').removeClass('hide');

--- a/cloudpebble/ide/templates/ide/index.html
+++ b/cloudpebble/ide/templates/ide/index.html
@@ -173,7 +173,7 @@
                     <div class="control-group">
                         <label class="control-label" for="import-github-branch">{% trans "Branch (optional)" %}</label>
                         <div class="controls">
-                            <input type="text" id="import-github-branch" placeholder="master" />
+                            <input type="text" id="import-github-branch" placeholder="main" />
                         </div>
                     </div>
                     {% if user.github_repo_sync %}

--- a/cloudpebble/ide/templates/ide/project/github.html
+++ b/cloudpebble/ide/templates/ide/project/github.html
@@ -13,7 +13,7 @@
             <div class="control-group">
                 <label class="control-label" for="github-branch">{% trans 'Branch' context "git branch" %}</label>
                 <div class="controls">
-                    <input type="text" class="span6" id="github-branch" placeholder="master" />
+                    <input type="text" class="span6" id="github-branch" placeholder="main" />
                 </div>
             </div>
             <div class="control-group">

--- a/cloudpebble/ide/tests/test_project_import_api.skip
+++ b/cloudpebble/ide/tests/test_project_import_api.skip
@@ -53,7 +53,7 @@ class TestProjectImportApi(TestCase):
         response = self.client.post('/ide/import/github', {
             'name': 'github-import',
             'repo': 'github.com/example/repo',
-            'branch': 'master',
+            'branch': 'main',
             'add_remote': 'false',
         })
         payload = json.loads(response.content)


### PR DESCRIPTION
… and GitHub-linked projects.

The GitHub-wide default 'master' -> 'main' transition was years ago. New projects should be using 'main'.

Signed-off by: Noah Kiser