### PR TITLE
compile: link commit SHAs to GitHub when repo is connected

### DIFF
--- a/cloudpebble/ide/api/project.py
+++ b/cloudpebble/ide/api/project.py
@@ -483,13 +483,19 @@ def _serialize_build(build, project):
     else:
         download = build.package_url if project.project_type == 'package' else build.pbw_url
         log = build.build_log_url
+    commit = build.commit_sha
+    commit_url = None
+    if commit and project.github_repo:
+        sha = commit[:-6] if commit.endswith('-dirty') else commit
+        commit_url = 'https://github.com/%s/commit/%s' % (project.github_repo, sha)
     return {
         'uuid': build.uuid,
         'state': build.state,
         'started': str(build.started),
         'finished': str(build.finished) if build.finished else None,
         'id': build.id,
-        'commit': build.commit_sha,
+        'commit': commit,
+        'commit_url': commit_url,
         'download': download,
         'log': log,
         'build_dir': build.get_url(),

--- a/cloudpebble/ide/static/ide/js/compile.js
+++ b/cloudpebble/ide/static/ide/js/compile.js
@@ -25,7 +25,13 @@ CloudPebble.Compile = (function() {
         tr.append($('<td class="build-id">' + (build.id === null ? '?' : build.id) + '</td>'));
         tr.append($('<td class="build-date">' + CloudPebble.Utils.FormatDatetime(build.started) + '</td>'));
         tr.append($('<td class="build-state">' + COMPILE_SUCCESS_STATES[build.state].english + '</td>'));
-        tr.append($('<td class="build-commit">').attr('title', build.commit || '').text(format_commit(build.commit)));
+        var commit_td = $('<td class="build-commit">').attr('title', build.commit || '');
+        if (build.commit_url) {
+            commit_td.append($('<a target="_blank" rel="noopener">').attr('href', build.commit_url).text(format_commit(build.commit)));
+        } else {
+            commit_td.text(format_commit(build.commit));
+        }
+        tr.append(commit_td);
         var pbw_badge = $('<td class="build-pbw">').appendTo(tr);
         if (build.state == 3) {
             pbw_badge.append($('<a class="btn btn-small">')
@@ -342,8 +348,13 @@ CloudPebble.Compile = (function() {
         } else {
             pane.find('#last-compilation, .build-stats').removeClass('hide');
             pane.find('#last-compilation-started').text(CloudPebble.Utils.FormatDatetime(build.started));
-            pane.find('#last-compilation-commit').toggleClass('hide', !build.commit)
-                .find('span').attr('title', build.commit || '').text(format_commit(build.commit));
+            var commit_link = pane.find('#last-compilation-commit').toggleClass('hide', !build.commit).find('a');
+            commit_link.attr('title', build.commit || '').text(format_commit(build.commit));
+            if (build.commit_url) {
+                commit_link.attr('href', build.commit_url);
+            } else {
+                commit_link.removeAttr('href');
+            }
             if(build.state > 1) {
                 pane.find('#last-compilation-time').removeClass('hide').find('span').text(CloudPebble.Utils.FormatInterval(build.started, build.finished));
                 pane.find('#last-compilation-log').removeClass('hide').attr('href', build.log).off('click').click(function(e) {

--- a/cloudpebble/ide/templates/ide/project/compile.html
+++ b/cloudpebble/ide/templates/ide/project/compile.html
@@ -94,7 +94,7 @@
             <p><label>{% trans 'Started:' context 'date/time' %}</label> <span id="last-compilation-started">April 17, 2013, 11:50 a.m.</span></p>
             <p id="last-compilation-time"><label>{% trans 'Build time:' context 'duration' %}</label> <span>0.98 seconds</span></p>
             <p><label>{% trans 'Status:' %}</label> <span id="last-compilation-status" class="label label-success">Successful</span></p>
-            <p id="last-compilation-commit" class="hide"><label>{% trans 'Commit:' %}</label> <span></span></p>
+            <p id="last-compilation-commit" class="hide"><label>{% trans 'Commit:' %}</label> <a target="_blank" rel="noopener"></a></p>
             <p id="last-compilation-size-aplite" class="hide"><label>{% trans 'Aplite Size:' %}</label> <span class="text"></span></p>
             <p id="last-compilation-size-basalt" class="hide"><label>{% trans 'Basalt Size:' %}</label> <span class="text"></span></p>
             <p id="last-compilation-size-chalk" class="hide"><label>{% trans 'Chalk Size:' %}</label> <span class="text"></span></p>


### PR DESCRIPTION
When a project has a linked GitHub repo, turn the commit SHA in the build history table and last-compilation panel into a clickable link to the commit on GitHub. Strips -dirty suffix before constructing the URL. Falls back to plain text when no repo is linked.

# Note
I could not test it myself as the locally run instance somehow fails to install the Github App. Despite linking it to my Github profile, it always shows "Cloud Dev Connection GitHub app is not configured."